### PR TITLE
Fixes Discord Link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,7 +32,7 @@
 
         <div class="social">
           <a href="https://twitter.com/pursuedpybear"><img src="{{ "/assets/twitter-circle.svg" | relative_url }}" title="@PursuedPyBear on Twitter"></a>
-          <a href="https://discord.gg/s7qx493"><img src="{{ "/assets/discord-black.svg" | relative_url }}" title="Join our Discord"></a>
+          <a href="https://discord.gg/uDbauD5"><img src="{{ "/assets/discord-black.svg" | relative_url }}" title="Join our Discord"></a>
         </div>
       </header>
       <section>


### PR DESCRIPTION
Got reports of the join link not working, generated a new invite with no expiration that should drop users into the introductions channel.