### PR TITLE
build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -eu
 
 prefix() {
     tmpfile=$(mktemp)

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ prefix() {
 }
 
 # Pull some files from other repos
-wget https://github.com/ppb/pursuedpybear/raw/master/CONTRIBUTING.md -O contributing.md
+wget https://github.com/ppb/pursuedpybear/raw/HEAD/CONTRIBUTING.md -O contributing.md
 prefix contributing.md <<EOF
 ---
 layout: default
@@ -15,7 +15,7 @@ title: How to Contribute
 ---
 EOF
 
-wget https://github.com/ppb/pursuedpybear/raw/master/CONTRIBUTORS.md -O contributors.md
+wget https://github.com/ppb/pursuedpybear/raw/HEAD/CONTRIBUTORS.md -O contributors.md
 prefix contributors.md <<EOF
 ---
 layout: default
@@ -23,7 +23,7 @@ title: Contributors
 ---
 EOF
 
-wget https://github.com/ppb/.github/raw/master/CODE_OF_CONDUCT.md -O coc.md
+wget https://github.com/ppb/.github/raw/HEAD/CODE_OF_CONDUCT.md -O coc.md
 prefix coc.md <<EOF
 ---
 layout: default


### PR DESCRIPTION
Fixing 2 major issues in `build.sh`:

- Error conditions were silently ignored, rather than causing the site's build to fail.
- The default branch name was hardcoded to `master`.


Following the deletion of that branch, and due to `wget` errors being ignored,
the CoC, contribution guidelines, and contributor list, became empty pages.

Many thanks to Gaëlle for noticing the issue.
